### PR TITLE
Remove old backup configurations

### DIFF
--- a/dts-demo/config/backup-mongodb/backup.conf
+++ b/dts-demo/config/backup-mongodb/backup.conf
@@ -48,7 +48,7 @@
 # 0 1 * * * default ./backup.sh -s
 # 0 4 * * * default ./backup.sh -s -v all
 # ============================================================
-mongo=identity-kit-db-bc/identity_kit_db
+# mongo=identity-kit-db-bc/identity_kit_db
 
 
 

--- a/dts-demo/config/backup-postgres/backup.conf
+++ b/dts-demo/config/backup-postgres/backup.conf
@@ -48,19 +48,10 @@
 # 0 1 * * * default ./backup.sh -s
 # 0 4 * * * default ./backup.sh -s -v all
 # ============================================================
-postgres=issuer-kit-wallet/agent-bcreg-wallet
-postgres=issuer-kit-wallet/agent-bcgov-citz-wallet
 postgres=issuer-kit-wallet/agent_a2a_wallet
-postgres=issuer-kit-wallet/agent_bcreg_wallet
-postgres=issuer-kit-wallet/agent_esr1_wallet
-postgres=issuer-kit-wallet/agent_esr2_wallet
-postgres=issuer-kit-wallet/agent_healthbc_wallet
-postgres=issuer-kit-wallet/agent_inoculation_wallet
-postgres=issuer-kit-wallet/agent_medlab_wallet
-postgres=issuer-kit-wallet/agent_openvp_wallet
-postgres=identity-kit-wallet-bc/identity_kit_agent_bc_wallet
+postgres=issuer-kit-wallet/agent_openvp_candy_wallet
+postgres=issuer-kit-wallet/agent_bcvcpilot_wallet
 postgres=email-verification-service-db/email-verification-service-db
-postgres=iiw-book-db/iiw-book-db
 
 # Schedule backup for 1am PST; system TZ is PST
 0 1 * * * default ./backup.sh -s


### PR DESCRIPTION
Removed old backup configurations that will become obsolete/unnecessary after turning off old demo deployments.
This change *must* be deployed *after* the demos have been decommissioned.

@WadeBarnes I am not sure about the OpenVP Candy issuer: I believe this is not used for the BC Verified Person, if that will go as well let me know and I will remove it from the config.