### PR TITLE
Add backup-mongo deploy configurations to vcauthn

### DIFF
--- a/dts-toip/backup-mongodb/dev-values.yaml
+++ b/dts-toip/backup-mongodb/dev-values.yaml
@@ -3,9 +3,9 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: i5okie/backup-mongo
+  repository: bcgovimages/backup-container-mongo
   pullPolicy: IfNotPresent
-  tag: 5.7.32
+  tag: 2.8
 
 imagePullSecrets: []
 nameOverride: ""

--- a/dts-toip/backup-mongodb/dev-values.yaml
+++ b/dts-toip/backup-mongodb/dev-values.yaml
@@ -1,0 +1,130 @@
+# Default values for backup-storage.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: i5okie/backup-mongo
+  pullPolicy: IfNotPresent
+  tag: 5.7.32
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+backupConfig: |
+  mongo=vc-authn-oidc-mongodb-headless:27017/vcauthn
+
+  0 1 * * * default ./backup.sh -s
+  0 4 * * * default ./backup.sh -s -v all
+
+config:
+  []
+  # - filename: 60-tweaks.cnf
+  #   mountPath: /etc/my.cnf.d/60-tweaks.cnf
+  #   contents: |
+  #     [mysqld]
+  #     innodb_page_size=32k
+
+persistence:
+  backup:
+    size: 8Gi
+    mountPath: /backups/
+    storageClassName: netapp-file-backup
+    storageAccessMode: ReadWriteOnce
+  verification:
+    size: 1Gi
+    mountPath: /var/lib/mongodb/data
+    storageClassName: netapp-block-standard
+    storageAccessMode: ReadWriteOnce
+
+db:
+  secretName: "vc-authn-oidc-controller-db"
+  usernameKey: "mongodb-user"
+  passwordKey: "mongodb-password"
+
+env:
+  BACKUP_STRATEGY:
+    value: "rolling"
+    secure: false
+  BACKUP_DIR:
+    value: "/backups/"
+  BACKUP_CONF:
+    value: "/conf/backup.conf"
+  NUM_BACKUPS:
+    value: ""
+  DAILY_BACKUPS:
+    value: "12"
+  WEEKLY_BACKUPS:
+    value: "8"
+  MONTHLY_BACKUPS:
+    value: "2"
+  BACKUP_PERIOD:
+    value: ""
+  MONGODB_AUTHENTICATION_DATABASE:
+    value: "vcauthn"
+  MSSQL_SA_PASSWORD:
+    value: ""
+    secure: true
+  TAG_NAME:
+    value: dev
+  TABLE_SCHEMA:
+    value: ""
+  FTP_URL:
+    value: ""
+    secure: true
+  FTP_USER:
+    value: ""
+    secure: true
+  FTP_PASSWORD:
+    value: ""
+    secure: true
+  WEBHOOK_URL:
+    value: ""
+    secure: true
+  ENVIRONMENT_NAME:
+    value: "e79518-dev"
+  ENVIRONMENT_FRIENDLY_NAME:
+    value: "Access to Audio Trust Over IP (dev)"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/dts-toip/backup-mongodb/prod-values.yaml
+++ b/dts-toip/backup-mongodb/prod-values.yaml
@@ -3,9 +3,9 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: i5okie/backup-mongo
+  repository: bcgovimages/backup-container-mongo
   pullPolicy: IfNotPresent
-  tag: 5.7.32
+  tag: 2.8
 
 imagePullSecrets: []
 nameOverride: ""

--- a/dts-toip/backup-mongodb/prod-values.yaml
+++ b/dts-toip/backup-mongodb/prod-values.yaml
@@ -1,0 +1,130 @@
+# Default values for backup-storage.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: i5okie/backup-mongo
+  pullPolicy: IfNotPresent
+  tag: 5.7.32
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+backupConfig: |
+  mongo=vc-authn-oidc-mongodb-headless:27017/vcauthn
+
+  0 1 * * * default ./backup.sh -s
+  0 4 * * * default ./backup.sh -s -v all
+
+config:
+  []
+  # - filename: 60-tweaks.cnf
+  #   mountPath: /etc/my.cnf.d/60-tweaks.cnf
+  #   contents: |
+  #     [mysqld]
+  #     innodb_page_size=32k
+
+persistence:
+  backup:
+    size: 24Gi
+    mountPath: /backups/
+    storageClassName: netapp-file-backup
+    storageAccessMode: ReadWriteOnce
+  verification:
+    size: 10Gi
+    mountPath: /var/lib/mongodb/data
+    storageClassName: netapp-block-standard
+    storageAccessMode: ReadWriteOnce
+
+db:
+  secretName: "vc-authn-oidc-controller-db"
+  usernameKey: "mongodb-user"
+  passwordKey: "mongodb-password"
+
+env:
+  BACKUP_STRATEGY:
+    value: "rolling"
+    secure: false
+  BACKUP_DIR:
+    value: "/backups/"
+  BACKUP_CONF:
+    value: "/conf/backup.conf"
+  NUM_BACKUPS:
+    value: ""
+  DAILY_BACKUPS:
+    value: "12"
+  WEEKLY_BACKUPS:
+    value: "8"
+  MONTHLY_BACKUPS:
+    value: "2"
+  BACKUP_PERIOD:
+    value: ""
+  MONGODB_AUTHENTICATION_DATABASE:
+    value: "vcauthn"
+  MSSQL_SA_PASSWORD:
+    value: ""
+    secure: true
+  TAG_NAME:
+    value: prod
+  TABLE_SCHEMA:
+    value: ""
+  FTP_URL:
+    value: ""
+    secure: true
+  FTP_USER:
+    value: ""
+    secure: true
+  FTP_PASSWORD:
+    value: ""
+    secure: true
+  WEBHOOK_URL:
+    value: ""
+    secure: true
+  ENVIRONMENT_NAME:
+    value: "e79518-prod"
+  ENVIRONMENT_FRIENDLY_NAME:
+    value: "Access to Audio Trust Over IP (prod)"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/dts-toip/backup-mongodb/test-values.yaml
+++ b/dts-toip/backup-mongodb/test-values.yaml
@@ -3,9 +3,9 @@
 # Declare variables to be passed into your templates.
 
 image:
-  repository: i5okie/backup-mongo
+  repository: bcgovimages/backup-container-mongo
   pullPolicy: IfNotPresent
-  tag: 5.7.32
+  tag: 2.8
 
 imagePullSecrets: []
 nameOverride: ""

--- a/dts-toip/backup-mongodb/test-values.yaml
+++ b/dts-toip/backup-mongodb/test-values.yaml
@@ -1,0 +1,130 @@
+# Default values for backup-storage.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: i5okie/backup-mongo
+  pullPolicy: IfNotPresent
+  tag: 5.7.32
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+backupConfig: |
+  mongo=vc-authn-oidc-mongodb-headless:27017/vcauthn
+
+  0 1 * * * default ./backup.sh -s
+  0 4 * * * default ./backup.sh -s -v all
+
+config:
+  []
+  # - filename: 60-tweaks.cnf
+  #   mountPath: /etc/my.cnf.d/60-tweaks.cnf
+  #   contents: |
+  #     [mysqld]
+  #     innodb_page_size=32k
+
+persistence:
+  backup:
+    size: 10Gi
+    mountPath: /backups/
+    storageClassName: netapp-file-backup
+    storageAccessMode: ReadWriteOnce
+  verification:
+    size: 5Gi
+    mountPath: /var/lib/mongodb/data
+    storageClassName: netapp-block-standard
+    storageAccessMode: ReadWriteOnce
+
+db:
+  secretName: "vc-authn-oidc-controller-db"
+  usernameKey: "mongodb-user"
+  passwordKey: "mongodb-password"
+
+env:
+  BACKUP_STRATEGY:
+    value: "rolling"
+    secure: false
+  BACKUP_DIR:
+    value: "/backups/"
+  BACKUP_CONF:
+    value: "/conf/backup.conf"
+  NUM_BACKUPS:
+    value: ""
+  DAILY_BACKUPS:
+    value: "12"
+  WEEKLY_BACKUPS:
+    value: "8"
+  MONTHLY_BACKUPS:
+    value: "2"
+  BACKUP_PERIOD:
+    value: ""
+  MONGODB_AUTHENTICATION_DATABASE:
+    value: "vcauthn"
+  MSSQL_SA_PASSWORD:
+    value: ""
+    secure: true
+  TAG_NAME:
+    value: test
+  TABLE_SCHEMA:
+    value: ""
+  FTP_URL:
+    value: ""
+    secure: true
+  FTP_USER:
+    value: ""
+    secure: true
+  FTP_PASSWORD:
+    value: ""
+    secure: true
+  WEBHOOK_URL:
+    value: ""
+    secure: true
+  ENVIRONMENT_NAME:
+    value: "e79518-test"
+  ENVIRONMENT_FRIENDLY_NAME:
+    value: "Access to Audio Trust Over IP (test)"
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  {}
+  # fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Add backup-mongodb deployment values for vcauthn for `dev`, `test`, and `prod` environments.
Uses [`bcgov/backup-storage`](https://github.com/bcgov/helm-charts/tree/master/charts/backup-storage) Helm chart